### PR TITLE
Workflow for checking that the project can be built on Linux and macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,55 @@
+name: Build
+
+on:
+  push:
+    paths:
+    - '.github/workflows/build.yml'
+    - 'source/**'
+  pull_request:
+    paths:
+    - '.github/workflows/build.yml'
+    - 'source/**'
+
+env:
+  CMAKE_BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest]
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies (macOS)
+      if: startsWith(matrix.os, 'macos')
+      run: |
+        brew update
+        brew install boost
+        brew install sfml@2
+        mkdir -p "${{ github.workspace }}/build"
+
+    - name: Install dependencies (Ubuntu)
+      if: startsWith(matrix.os, 'ubuntu')
+      run: |
+        sudo apt-get update
+        sudo apt-get -y install libboost-all-dev
+        sudo apt-get -y install libsfml-dev
+        sudo apt-get -y install zlib1g-dev
+
+    - name: Configure environment variables (macOS)
+      if: startsWith(matrix.os, 'macos')
+      run: echo "SFML_DIR=$(brew --prefix sfml@2)" >> $GITHUB_ENV
+
+    - name: Configure CMake
+      run: >-
+        cmake
+        -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }}
+        -B "${{ github.workspace }}/build"
+        -S "${{ github.workspace }}/source"
+
+    - name: Build
+      run: cmake --build "${{ github.workspace }}/build" --config ${{ env.CMAKE_BUILD_TYPE }} --verbose

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # SpecIde
 
+[![](https://github.com/MartianGirl/SpecIde/actions/workflows/build.yml/badge.svg)](https://github.com/MartianGirl/SpecIde/actions/workflows/build.yml)
+
 ## What is it?
 SpecIde is (yet another) ZX Spectrum (and, partially, Amstrad CPC) emulator.
 Currently, the ZX Spectrum emulation is quite accurate. The Amstrad CPC emulation


### PR DESCRIPTION
This tiny PR adds a workflow that builds the project on Linux and macOS, along with a badge for displaying the workflow status in the `README.md`.